### PR TITLE
Set correct hour format depending on the locale

### DIFF
--- a/app/src/main/java/me/blog/korn123/easydiary/activities/DiaryInsertActivity.kt
+++ b/app/src/main/java/me/blog/korn123/easydiary/activities/DiaryInsertActivity.kt
@@ -14,6 +14,7 @@ import android.speech.RecognizerIntent
 import android.support.v4.content.ContextCompat
 import android.support.v4.graphics.ColorUtils
 import android.support.v7.app.AlertDialog
+import android.text.format.DateFormat
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
@@ -258,7 +259,7 @@ class DiaryInsertActivity : EasyDiaryActivity() {
     
     private fun setupDialog() {
         mDatePickerDialog = DatePickerDialog(this, mStartDateListener, mYear, mMonth - 1, mDayOfMonth)
-        mTimePickerDialog = TimePickerDialog(this, mTimeSetListener, mHourOfDay, mMinute, false)
+        mTimePickerDialog = TimePickerDialog(this, mTimeSetListener, mHourOfDay, mMinute, DateFormat.is24HourFormat(this))
     }
 
     private fun setupShowcase() {

--- a/app/src/main/java/me/blog/korn123/easydiary/activities/DiaryUpdateActivity.kt
+++ b/app/src/main/java/me/blog/korn123/easydiary/activities/DiaryUpdateActivity.kt
@@ -13,6 +13,7 @@ import android.os.Environment
 import android.speech.RecognizerIntent
 import android.support.v4.graphics.ColorUtils
 import android.support.v7.app.AlertDialog
+import android.text.format.DateFormat
 import android.view.MenuItem
 import android.view.View
 import android.view.inputmethod.InputMethodManager
@@ -144,7 +145,7 @@ class DiaryUpdateActivity : EasyDiaryActivity() {
             }
             R.id.timePicker -> {
                 if (mTimePickerDialog == null) {
-                    mTimePickerDialog = TimePickerDialog(this, mTimeSetListener, mHourOfDay, mMinute, false)
+                    mTimePickerDialog = TimePickerDialog(this, mTimeSetListener, mHourOfDay, mMinute, DateFormat.is24HourFormat(this))
                 }
                 mTimePickerDialog?.show()
             }


### PR DESCRIPTION
Some countries (like Germany) use a 24h time format while the others (like the USA) use the 12h format. This PR sets the time picker to use the correct one.