### PR TITLE
Fix decompress

### DIFF
--- a/app/src/androidTest/java/me/blog/korn123/easydiary/helper/ZipHelperDecompressTest.kt
+++ b/app/src/androidTest/java/me/blog/korn123/easydiary/helper/ZipHelperDecompressTest.kt
@@ -1,0 +1,166 @@
+package me.blog.korn123.easydiary.helper
+
+import android.content.Context
+import android.net.Uri
+import android.os.Build
+import android.os.Environment
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assume
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.io.FileOutputStream
+import java.nio.file.Files
+import java.util.UUID
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+@RunWith(AndroidJUnit4::class)
+class ZipHelperDecompressTest {
+    private lateinit var context: Context
+    private lateinit var workingRoot: File
+    private lateinit var testId: String
+    private val archives = mutableListOf<File>()
+    private val createdLinks = mutableListOf<File>()
+    private val outsideFiles = mutableListOf<File>()
+    private val outsideDirectories = mutableListOf<File>()
+    private val rootedAbsoluteDestinations = mutableListOf<File>()
+
+    @Before
+    fun setUp() {
+        context = InstrumentationRegistry.getInstrumentation().targetContext
+        testId = "ziphelper-containment-${UUID.randomUUID()}"
+        workingRoot = File(Environment.getExternalStorageDirectory(), "EasyDiary")
+        assertTrue("The configured EasyDiary working directory must be available to extraction", workingRoot.exists() || workingRoot.mkdirs())
+    }
+
+    @After
+    fun tearDown() {
+        createdLinks.forEach { it.delete() }
+
+        if (::workingRoot.isInitialized && ::testId.isInitialized) {
+            File(workingRoot, testId).deleteRecursively()
+        }
+
+        archives.forEach { it.delete() }
+        rootedAbsoluteDestinations.forEach(::deleteFileAndEmptyParents)
+        outsideFiles.forEach(::deleteFileAndEmptyParents)
+        outsideDirectories.forEach { it.deleteRecursively() }
+    }
+
+    @Test
+    fun decompressUri_extractsNestedRelativeEntryBeneathWorkingRoot() {
+        val entryName = "$testId/nested/relative-entry.txt"
+        val archive = createArchive(entryName, "contained content")
+
+        ZipHelper(context).decompress(Uri.fromFile(archive))
+
+        val extractedFile = File(workingRoot, entryName)
+        assertTrue("A normal relative entry should be extracted", extractedFile.isFile)
+        assertEquals("contained content", extractedFile.readText())
+        assertTrue(
+            "The extracted entry must remain below the canonical working-directory root",
+            extractedFile.canonicalPath.startsWith(workingRoot.canonicalPath + File.separator)
+        )
+    }
+
+    @Test
+    fun decompressUri_rejectsTraversalEntryWithoutCreatingOutsideRootFile() {
+        val outsideFile = File(workingRoot.parentFile, "$testId-traversal.txt")
+        outsideFiles += outsideFile
+        outsideFile.delete()
+        val archive = createArchive("../${outsideFile.name}", "must not escape")
+
+        ZipHelper(context).decompress(Uri.fromFile(archive))
+
+        assertFalse("A traversal entry must not create a file outside the working root", outsideFile.exists())
+    }
+
+    @Test
+    fun decompressUri_rejectsAbsoluteEntryWithoutCreatingDestination() {
+        val outsideFile = File(context.cacheDir, "$testId-absolute.txt")
+        outsideFiles += outsideFile
+        outsideFile.delete()
+        val absoluteEntryName = outsideFile.absolutePath
+        val rootedAbsoluteDestination = File(
+            workingRoot,
+            absoluteEntryName.removePrefix(File.separator)
+        )
+        rootedAbsoluteDestinations += rootedAbsoluteDestination
+        rootedAbsoluteDestination.delete()
+        val archive = createArchive(absoluteEntryName, "must not be extracted")
+
+        ZipHelper(context).decompress(Uri.fromFile(archive))
+
+        assertFalse("An absolute ZIP entry must not create its absolute destination", outsideFile.exists())
+        assertFalse(
+            "An absolute ZIP entry must be rejected rather than treated as a relative destination",
+            rootedAbsoluteDestination.exists()
+        )
+    }
+
+    @Test
+    fun decompressUri_rejectsEntryWhoseExistingParentLinkResolvesOutsideWorkingRoot() {
+        Assume.assumeTrue(
+            "Symbolic-link containment coverage requires Android O or later",
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+        )
+
+        val linkedParent = File(workingRoot, "$testId-linked-parent")
+        val outsideDirectory = File(context.cacheDir, "$testId-link-target")
+        createdLinks += linkedParent
+        outsideDirectories += outsideDirectory
+        linkedParent.delete()
+        outsideDirectory.deleteRecursively()
+        assertTrue("The link target directory must be created for this test", outsideDirectory.mkdirs())
+
+        try {
+            Files.createSymbolicLink(linkedParent.toPath(), outsideDirectory.toPath())
+        } catch (exception: Exception) {
+            Assume.assumeNoException(
+                "The current Android test filesystem does not permit symbolic-link setup",
+                exception
+            )
+            return
+        }
+
+        val escapedFile = File(outsideDirectory, "escaped-through-link.txt")
+        outsideFiles += escapedFile
+        val archive = createArchive("${linkedParent.name}/${escapedFile.name}", "must not follow link")
+
+        ZipHelper(context).decompress(Uri.fromFile(archive))
+
+        assertFalse(
+            "A destination whose existing parent link resolves outside the working root must be rejected",
+            escapedFile.exists()
+        )
+    }
+
+    private fun createArchive(entryName: String, content: String): File {
+        val archive = File(context.cacheDir, "$testId-${UUID.randomUUID()}.zip")
+        archives += archive
+        ZipOutputStream(FileOutputStream(archive)).use { output ->
+            output.putNextEntry(ZipEntry(entryName))
+            output.write(content.toByteArray())
+            output.closeEntry()
+        }
+        return archive
+    }
+
+    private fun deleteFileAndEmptyParents(file: File) {
+        file.delete()
+        var parent = file.parentFile
+        while (parent != null && parent != workingRoot) {
+            if (!parent.delete()) {
+                return
+            }
+            parent = parent.parentFile
+        }
+    }
+}

--- a/app/src/main/java/me/blog/korn123/easydiary/helper/ZipHelper.kt
+++ b/app/src/main/java/me/blog/korn123/easydiary/helper/ZipHelper.kt
@@ -225,12 +225,20 @@ class ZipHelper(
         try {
             val zipInputStream = ZipInputStream(uriStream)
             var zipEntry: ZipEntry? = zipInputStream.nextEntry
-            val workingPath = EasyDiaryUtils.getApplicationDataDirectory(context) + WORKING_DIRECTORY
+            val workingDirectory = File(EasyDiaryUtils.getApplicationDataDirectory(context) + WORKING_DIRECTORY).canonicalFile
+            val workingDirectoryPrefix = if (workingDirectory.path.endsWith(File.separator)) workingDirectory.path else workingDirectory.path + File.separator
             var index = 0
             while (zipEntry != null) {
                 if (!isOnProgress) break
                 val fileName = zipEntry.name
-                val newFile = File(workingPath + fileName)
+                if (File(fileName).isAbsolute) {
+                    throw IOException("ZIP entry has an absolute path: $fileName")
+                }
+
+                val newFile = File(workingDirectory, fileName).canonicalFile
+                if (!newFile.path.startsWith(workingDirectoryPrefix)) {
+                    throw IOException("ZIP entry escapes the working directory: $fileName")
+                }
 
                 File(newFile.parent).mkdirs()
                 val fileOutputStream = FileOutputStream(newFile)
@@ -257,7 +265,6 @@ class ZipHelper(
             e.printStackTrace()
         }
     }
-
     fun decompress(
         zipFileName: String,
         compressDirectoryName: String,


### PR DESCRIPTION
## What does this implement/fix?

| Property | Value |
|---|---|
| Method | `decompress` |
| Class | `me.blog.korn123.easydiary.helper.ZipHelper` |
| File | `app/src/main/java/me/blog/korn123/easydiary/helper/ZipHelper.kt` |
| Specification | `ZipSlipSpec` |
| Analysis tool | `static:manual` |

## Summary

### Observed dynamic-analysis failure

The dynamic-analysis run by `static:manual` reported (`ZipSlipSpec`) while exercising `me.blog.korn123.easydiary.helper.ZipHelper.decompress`:

> Static candidate (not executed): ZIP entry names reach File(workingPath + fileName) and FileOutputStream without canonical destination containment validation (CWE-22).

### Root cause

The reviewed Uri? overload directly derives the output File from a ZIP entry name and opens it for writing without a local resolved-destination containment check against the extraction root.

### Correction strategy

Treat the working directory as the sole extraction root: resolve the root and each candidate destination before side effects, enforce resolved containment before mkdirs or output opening, and fail closed for non-contained entries. Preserve normal relative, contained archive entries.

### Coordinated changes

- `app/src/main/java/me/blog/korn123/easydiary/helper/ZipHelper.kt`: Resolve the extraction root once and canonicalize each candidate destination before mkdirs or FileOutputStream. Reject native absolute ZIP names and canonical paths that do not begin with the root plus a path separator, preventing ../ traversal and pre-existing symlink traversal while retaining valid nested relative entries. The sibling String/String overload remains unchanged.
- `app/src/androidTest/java/me/blog/korn123/easydiary/helper/ZipHelperDecompressTest.kt`: Adds instrumentation-only regression tests for the coordinated ZipHelper.decompress(Uri?) containment validation. It verifies normal nested extraction, traversal rejection, native absolute-name rejection, and symlink-resolved escape rejection where symbolic-link creation is supported by the device filesystem.

### Verification included

- Edit app/src/androidTest/java/me/blog/korn123/easydiary/helper/ZipHelperDecompressTest.kt to extract an archive containing a valid nested relative entry and assert that its content is written beneath the resolved working-directory root.
- Edit app/src/androidTest/java/me/blog/korn123/easydiary/helper/ZipHelperDecompressTest.kt to extract archives containing ../escape and an absolute-path entry, assert decompression rejects each archive, and assert no outside-root destination is created.
- Edit app/src/androidTest/java/me/blog/korn123/easydiary/helper/ZipHelperDecompressTest.kt to test containment under applicable pre-existing path/link conditions when supported by the Android test environment; explicitly skip or gate only unsupported link setup rather than weakening the non-contained-entry assertions.
- Extract a nested relative entry and assert its content and canonical containment beneath the working root.
- Extract a ../ traversal entry and assert that no file appears outside the working root.
- Extract a native absolute-path entry and assert that neither the absolute destination nor a relative reinterpretation is created.
- When Android O-or-later symbolic-link setup is supported, extract through a pre-existing parent symbolic link and assert that its outside target is not written.

### Residual review requirements

The patch remains review-only until these assumptions are confirmed:

- WORKING_DIRECTORY identifies an application-private extraction directory rather than the filesystem root; the separator-delimited canonical-prefix check therefore distinguishes descendants from sibling paths sharing the same textual prefix.
- Android's File.canonicalFile resolves applicable existing symlink components for the runtime API levels supported by this app; link-setup coverage must be conditionally gated where the instrumentation environment prohibits symbolic links.
- The existing method intentionally handles IOException internally, so rejection is observable through halted extraction and absence of an outside-root file rather than through a newly exposed exception contract.
- The application's configured working-directory mapping remains Environment.getExternalStorageDirectory()/EasyDiary; the supplied production API outline does not expose a working-root accessor that would allow this test to derive the root directly.
- The instrumentation environment permits the app/test process to create and remove uniquely named files under the configured EasyDiary external-storage root; this is also necessary for the production extraction behavior being tested.
- ContentResolver.openInputStream(Uri.fromFile(archive)) is supported by the Android instrumentation runtime used for these tests.
- Symbolic-link coverage is explicitly skipped only when the runtime is below Android O or when its filesystem/security policy rejects symbolic-link creation; traversal and absolute-entry assertions remain unconditional.

## How was this tested?

- [x] Automated test coverage added in 1 test file(s)
- [x] The patched module compiles successfully (`:app:compileFossDebugKotlin`); the full multi-module build was not completed in this environment
- [ ] Confirmed by a project maintainer

## Reviewer notes

Do not merge until these assumptions and blockers are resolved:

- WORKING_DIRECTORY identifies an application-private extraction directory rather than the filesystem root; the separator-delimited canonical-prefix check therefore distinguishes descendants from sibling paths sharing the same textual prefix.
- Android's File.canonicalFile resolves applicable existing symlink components for the runtime API levels supported by this app; link-setup coverage must be conditionally gated where the instrumentation environment prohibits symbolic links.
- The existing method intentionally handles IOException internally, so rejection is observable through halted extraction and absence of an outside-root file rather than through a newly exposed exception contract.
- The application's configured working-directory mapping remains Environment.getExternalStorageDirectory()/EasyDiary; the supplied production API outline does not expose a working-root accessor that would allow this test to derive the root directly.
- The instrumentation environment permits the app/test process to create and remove uniquely named files under the configured EasyDiary external-storage root; this is also necessary for the production extraction behavior being tested.
- ContentResolver.openInputStream(Uri.fromFile(archive)) is supported by the Android instrumentation runtime used for these tests.
- Symbolic-link coverage is explicitly skipped only when the runtime is below Android O or when its filesystem/security policy rejects symbolic-link creation; traversal and absolute-entry assertions remain unconditional.

## Additional context

I’m an undergraduate Computer Engineering student at the University of Brasília (UnB), and this contribution is part of a research project involving software security analysis.

I’m happy to adjust the implementation to better match the project’s architecture, coding conventions, or maintainers’ recommendations.